### PR TITLE
Relax Poison version requirement

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule Raven.Mixfile do
 
   defp deps do
     [
-      {:hackney, "~> 0.14.1"},
+      {:hackney, "~> 1.0"},
       {:uuid, "~> 0.1.5"},
       {:poison, ">= 1.2.0"}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -24,10 +24,10 @@ defmodule Raven.Mixfile do
     [
       {:hackney, "~> 0.14.1"},
       {:uuid, "~> 0.1.5"},
-      {:poison, "~> 1.2.0"}
+      {:poison, ">= 1.2.0"}
     ]
   end
-  
+
   defp package do
     [
       files: ["lib", "LICENSE", "mix.exs", "README.md"],

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
-%{"hackney": {:hex, :hackney, "0.14.3"},
-  "idna": {:hex, :idna, "1.0.1"},
+%{"hackney": {:hex, :hackney, "1.1.0"},
+  "idna": {:hex, :idna, "1.0.2"},
   "poison": {:hex, :poison, "1.3.1"},
+  "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"},
   "uuid": {:hex, :uuid, "0.1.5"}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,4 @@
-%{"hackney": {:package, "0.14.1"},
-  "idna": {:package, "1.0.1"},
-  "poison": {:package, "1.2.0"},
-  "uuid": {:package, "0.1.5"}}
+%{"hackney": {:hex, :hackney, "0.14.3"},
+  "idna": {:hex, :idna, "1.0.1"},
+  "poison": {:hex, :poison, "1.3.1"},
+  "uuid": {:hex, :uuid, "0.1.5"}}


### PR DESCRIPTION
The public API hasn't changed enough to matter here. There's no reason to stay on 1.2.x as far as I can tell.